### PR TITLE
[FEAT] 뉴스 스크랩 저장 및 삭제

### DIFF
--- a/models/ScrapNews.js
+++ b/models/ScrapNews.js
@@ -2,20 +2,21 @@ const mongoose = require("mongoose");
 
 const ScrapNewsSchema = new mongoose.Schema(
   {
-    title: String,
-    content: String,
-    hasImage: Boolean,
-    image: String,
-    sourceName: String,
-    sourceImage: String,
-    defaultBookmarked: Boolean,
-    userId: String,
+    title: { type: String, required: true },
+    link: { type: String, required: true }, // 링크 추가
+    pubDate: { type: Date, required: true }, // 발행일 (Date 타입)
+    content: String, // 필수는 아님
+    hasImage: Boolean, // 필수는 아님
+    image: String, // 필수는 아님
+    sourceName: { type: String, required: true },
+    sourceImage: String, // 필수는 아님
+    userId: { type: String, required: true },
   },
   { collection: "scrap_news" }
 );
 
-// 계정 DB
-const ScrapNews = mongoose.model("ScrapNews", ScrapNewsSchema);
+// userId와 link 조합에 대한 unique 제약 조건 (선택 사항)
+ScrapNewsSchema.index({ userId: 1, link: 1 }, { unique: true, sparse: true });
 
-// User 모델 외부로 내보내기기
+const ScrapNews = mongoose.model("ScrapNews", ScrapNewsSchema);
 module.exports = ScrapNews;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const mongoose = require("mongoose");
 const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
@@ -57,10 +58,17 @@ router.use(express.static("public")); // 정적 파일 제공
 
 // 사용자 정보 불러오기
 router.get("/info/:userId", async (req, res) => {
+  // authenticateToken 미들웨어 제거
+
   const { userId } = req.params;
 
+  // userId가 ObjectId 형식인지 확인
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ message: "잘못된 사용자 ID 형식입니다." });
+  }
+
   try {
-    const user = await User.findById(userId);
+    const user = await User.findById(userId); // userId를 사용하여 사용자 정보 조회
     if (!user) {
       return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
     }
@@ -99,14 +107,23 @@ router.put("/profile-change", upload.single("image"), async (req, res) => {
 
 // 스크랩한 뉴스 가져오기
 router.get("/scrapnews", async (req, res) => {
+  // 미들웨어 제거
   const userId = req.query.userId;
+  // userId가 ObjectId 형식인지 확인
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ message: "잘못된 사용자 ID 형식입니다." });
+  }
+
+  // *** 주의: 여기서는 userId를 신뢰합니다.  실제 서비스에서는 이렇게 하면 안 됩니다. ***
+  // if (req.user.id !== userId) { // 이 부분을 제거하거나 주석 처리
+  //   return res.status(403).json({ message: '권한이 없습니다.' });
+  // }
 
   try {
     const newsList = await ScrapNews.find({ userId: userId });
-    //const newsList = await ScrapNews.find();
     res.json(newsList);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    res.status(500).json({ message: err.message }); // 수정된 부분
   }
 });
 
@@ -186,6 +203,65 @@ router.put("/myportfolio-change", async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: "핀 수정 실패" });
+  }
+});
+
+router.post("/scrapnews", async (req, res) => {
+  const { userId, title, link, pubDate, sourceName, isMarked } = req.body;
+
+  // userId가 ObjectId 형식인지 확인
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ message: "잘못된 사용자 ID 형식입니다." });
+  }
+
+  // pubDate를 Date 객체로 변환
+  const receivedDate = new Date(pubDate);
+  if (isNaN(receivedDate.getTime())) {
+    return res.status(400).json({ message: "잘못된 날짜 형식입니다." });
+  }
+
+  // *** 주의: 여기서는 userId를 신뢰합니다.  실제 서비스에서는 이렇게 하면 안 됩니다. ***
+  // if (req.user.id !== userId) { // 이 부분을 제거하거나 주석 처리
+  //   return res.status(403).json({ message: '권한이 없습니다.' });
+  // }
+
+  if (!userId || !title || !link || !pubDate || !sourceName) {
+    return res.status(400).json({ message: "필수 정보가 누락되었습니다." });
+  }
+
+  try {
+    if (isMarked) {
+      // 스크랩 (DB에 추가)
+      const existingNews = await ScrapNews.findOne({ userId, link });
+      if (existingNews) {
+        return res.status(409).json({ message: "이미 스크랩된 뉴스입니다." });
+      }
+
+      const newScrapNews = new ScrapNews({
+        userId,
+        title,
+        link,
+        pubDate: receivedDate,
+        sourceName,
+      });
+      await newScrapNews.save();
+      res
+        .status(201)
+        .json({ message: "뉴스가 스크랩되었습니다.", news: newScrapNews });
+    } else {
+      // 스크랩 취소 (DB에서 제거)
+      const deletedNews = await ScrapNews.findOneAndDelete({ userId, link });
+      if (!deletedNews) {
+        return res
+          .status(404)
+          .json({ message: "스크랩된 뉴스를 찾을 수 없습니다." });
+      }
+
+      res.status(200).json({ message: "뉴스 스크랩이 취소되었습니다." });
+    }
+  } catch (error) {
+    console.error("뉴스 스크랩/취소 중 오류:", error);
+    res.status(500).json({ message: "서버 오류", error: error.message });
   }
 });
 


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- close #이슈번호 -->

close #42 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.  -->

정보제공 페이지의 뉴스 페이지에서 특정 뉴스의 북마크를 클릭하면 DB에 저장됨.
마이페이지 스크랩한 뉴스에서 북마크를 클릭하면 DB에서 삭제됨

현재 뉴스페이지에서 뉴스를 스크랩하고 새로고침하면 북마크 표시가 저장되지 않는 문제가 있음. 

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

- [ ] PR 제목 규칙에 맞게 작성 했나요?
- [ ] 관련된 이슈 번호를 작성했나요? (<!--- close #이슈번호 -->)
- [ ] 모든 변경 사항을 다시 한번 검토했나요?
